### PR TITLE
chore: update .gitignore to exclude documentation artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,10 @@ pages/.astro/
 pages/dist/
 pages/src/content/docs/
 
+# Generated documentation artifacts (deployed to docs branch)
+dist/
+.astro/
+
 # OpenCode context (project-specific, not for repo)
 .context/
 
@@ -34,6 +38,3 @@ fonts/*.otf
 !fonts/.gitkeep
 !fonts/test.html
 
-# Allow GitHub workflows and scripts
-!.github/
-!.github/**


### PR DESCRIPTION
## Summary

Updates .gitignore to better handle documentation build artifacts and cleanup redundant rules.

### Changes Made

- ✅ Added exclusions for generated documentation artifacts (`dist/`, `.astro/`)
- ✅ Removed redundant GitHub workflows allow rules
- ✅ Improved documentation build artifact management

### Testing Notes

- All existing tests pass
- TypeScript compilation succeeds
- No functional changes to code
- Only affects which files are tracked by git

### Related Issues

This change improves repository hygiene by ensuring build artifacts from documentation generation are properly excluded from version control.